### PR TITLE
Handle a missing order reference in the transaction webhooks

### DIFF
--- a/Services/WalleeTransactionService.php
+++ b/Services/WalleeTransactionService.php
@@ -890,11 +890,17 @@ class WalleeTransactionService
     }
 
     /**
-     * @param string $orderReference
+     * @param string|null $orderReference
      * @return void
      */
-    public function handleNextOrderReferenceNumber(string $orderReference): void
+    public function handleNextOrderReferenceNumber(?string $orderReference): void
     {
+        // Orders created by the shop before payment draw their number from the native
+        // JTL counter, so no reference reaches the metadata and there is nothing to advance.
+        if ($orderReference === null || $orderReference === '') {
+            return;
+        }
+
         if ($this->isPreventFromDuplicatedOrders() === false) {
             // Updates order number for next order. Increase by 1 if is needed
             WalleeHelper::createOrderNo(true, $orderReference);

--- a/Webhooks/Strategies/WalleeNameOrderUpdateTransactionInvoiceStrategy.php
+++ b/Webhooks/Strategies/WalleeNameOrderUpdateTransactionInvoiceStrategy.php
@@ -71,7 +71,7 @@ class WalleeNameOrderUpdateTransactionInvoiceStrategy implements WalleeOrderUpda
 
                 $order = new Bestellung($orderId);
                 $this->transactionService->addIncomingPayment((string)$transactionId, $order, $transaction);
-                $this->transactionService->handleNextOrderReferenceNumber($transaction->getMetaData()['order_no']);
+                $this->transactionService->handleNextOrderReferenceNumber($transaction->getMetaData()['order_no'] ?? null);
                 print 'Order ' . $orderId . ' status was updated to paid. Triggered by Transaction Invoice webhook.';
                 break;
         }

--- a/Webhooks/Strategies/WalleeNameOrderUpdateTransactionStrategy.php
+++ b/Webhooks/Strategies/WalleeNameOrderUpdateTransactionStrategy.php
@@ -67,7 +67,7 @@ class WalleeNameOrderUpdateTransactionStrategy implements WalleeOrderUpdateStrat
                     $orderData = $order->fuelleBestellung();
                     $this->transactionService->addIncomingPayment((string)$transactionId, $orderData, $transaction);
                     $this->transactionService->updateWawiSyncFlag($orderId, $this->transactionService::LET_SYNC_TO_WAWI);
-                    $this->transactionService->handleNextOrderReferenceNumber($transaction->getMetaData()['order_no']);
+                    $this->transactionService->handleNextOrderReferenceNumber($transaction->getMetaData()['order_no'] ?? null);
                 }
                 break;
 
@@ -75,7 +75,7 @@ class WalleeNameOrderUpdateTransactionStrategy implements WalleeOrderUpdateStrat
                 $order = new Bestellung($orderId);
                 if ($order && (int )$order->cStatus === \BESTELLUNG_STATUS_OFFEN) {
                     $this->transactionService->updateWawiSyncFlag($orderId, $this->transactionService::LET_SYNC_TO_WAWI);
-                    $this->transactionService->handleNextOrderReferenceNumber($transaction->getMetaData()['order_no']);
+                    $this->transactionService->handleNextOrderReferenceNumber($transaction->getMetaData()['order_no'] ?? null);
                 }
                 break;
 

--- a/Webhooks/WalleeWebhookManager.php
+++ b/Webhooks/WalleeWebhookManager.php
@@ -96,7 +96,8 @@ class WalleeWebhookManager
                 $transactionStateFromWebhook = $this?->data['state'] ?? null;
 
                 $transaction = $this->transactionService->getTransactionFromPortal($entityId);
-                $orderId = (int)$transaction->getMetaData()['orderId'] ?? null;
+                $metaData = $transaction->getMetaData() ?? [];
+                $orderId = isset($metaData['orderId']) ? (int)$metaData['orderId'] : null;
 
                 if ($this->shouldSendAuthorizationEmail($transactionStateFromWebhook, $transaction, $orderId)) {
                     $this->transactionService->sendEmail($orderId, 'authorization');


### PR DESCRIPTION
`handleNextOrderReferenceNumber()` declares a non-nullable `string` parameter, but the `order_no` metadata entry is `null` whenever the shop is configured to create the order before payment.

`confirmTransaction()` initialises `$orderReferenceNumber` to `null` (`Services/WalleeTransactionService.php:150`), assigns it only on the create-order-after-payment branch, and writes it into the transaction metadata either way (`:200`). Under `strict_types` the webhook strategies then raise a `TypeError`, so `frontend/wallee_webhook.php` answers with a 500 and the handler never reaches `updateTransactionStatus()`. Two consequences follow: `wallee_transactions.state` keeps its previous value, and the authorization mail dispatched from `WalleeWebhookManager` is never sent.

This accepts a nullable reference and returns early when none is present. Those orders take their number from the native JTL counter, so there is no plugin-side counter to advance. The three call sites also read the metadata entry with `?? null`, so transactions created by older plugin versions no longer emit an undefined-key warning.

Separately, `WalleeWebhookManager` read the order id as `(int)$transaction->getMetaData()['orderId'] ?? null`. The cast binds tighter than `??`, so the value was never `null`, the `$orderId === null` guard in `shouldSendAuthorizationEmail()` could not fire, and an authorization mail could be attempted for order 0 when the metadata is absent. It is now read through `isset()`.

Symptoms reported in #9, #2 and #6.

Verified with `php -l` on PHP 8.3. I have no JTL Shop instance to exercise the webhook end to end, so a check against a sandbox space would be welcome.
