### PR TITLE
Retry transaction updates that lose the optimistic lock

### DIFF
--- a/Services/WalleeTransactionService.php
+++ b/Services/WalleeTransactionService.php
@@ -18,6 +18,7 @@ use Plugin\jtl_wallee\WalleeHelper;
 use stdClass;
 use Wallee\Sdk\ApiClient;
 use Wallee\Sdk\ApiException;
+use Wallee\Sdk\VersioningException;
 use Wallee\Sdk\Model\{AddressCreate,
   CreationEntityState,
   CriteriaOperator,
@@ -44,6 +45,8 @@ class WalleeTransactionService
 {
     private const MAX_RETRIES = 12;
     private const PAUSE_DURATION = 5;
+    private const VERSION_CONFLICT_RETRIES = 3;
+    private const VERSION_CONFLICT_PAUSE_MICROSECONDS = 200000;
     public const LET_SYNC_TO_WAWI = 'N';
     public const NOT_SYNC_TO_WAWI = 'Y';
 
@@ -331,7 +334,6 @@ class WalleeTransactionService
         }
 
         $pendingTransaction->setId($transactionId);
-        $pendingTransaction->setVersion($transaction->getVersion());
 
         $lineItems = $this->getLineItems($_SESSION['Warenkorb']->PositionenArr);
         $pendingTransaction->setLineItems($lineItems);
@@ -343,8 +345,33 @@ class WalleeTransactionService
         $pendingTransaction->setBillingAddress($billingAddress);
         $pendingTransaction->setShippingAddress($shippingAddress);
 
-        return $this->apiClient->getTransactionService()
-            ->update($this->spaceId, $pendingTransaction);
+        // The version read above is stale as soon as another request updates the same
+        // transaction, which happens routinely because this runs from five cart hooks and
+        // the Smarty output filter. Re-read the version and retry instead of surfacing the
+        // conflict to the customer.
+        for ($attempt = 1; ; $attempt++) {
+            $pendingTransaction->setVersion($transaction->getVersion());
+
+            try {
+                return $this->apiClient->getTransactionService()
+                    ->update($this->spaceId, $pendingTransaction);
+            } catch (VersioningException $e) {
+                if ($attempt >= self::VERSION_CONFLICT_RETRIES) {
+                    WalleeHelper::log(
+                        'updateTransaction: giving up on transaction ' . $transactionId
+                        . ' after ' . $attempt . ' version conflicts.'
+                    );
+                    throw $e;
+                }
+
+                usleep(self::VERSION_CONFLICT_PAUSE_MICROSECONDS);
+
+                $transaction = $this->getTransactionFromPortal($transactionId);
+                if (empty($transaction) || empty($transaction->getVersion())) {
+                    throw $e;
+                }
+            }
+        }
     }
 
     /**

--- a/Services/WalleeTransactionService.php
+++ b/Services/WalleeTransactionService.php
@@ -221,16 +221,19 @@ class WalleeTransactionService
         try {
             $this->apiClient->getTransactionService()
                 ->confirm($this->spaceId, $pendingTransaction);
-        } catch (ApiException $e) {
+        } catch (ApiException | VersioningException $e) {
             // The JTL order and the local transaction record were created above
             // before the API call. If confirm fails (e.g. HTTP 442 from server-side
             // address validation), the customer never reaches the payment page and
-            // no webhook will ever flip the order out of NOT_SYNC_TO_WAWI — leaving
+            // no webhook will ever flip the order out of NOT_SYNC_TO_WAWI, leaving
             // the order stranded. Cancel it explicitly so stock is restored and the
             // order is removed via the native payment-method flow.
+            // VersioningException is caught alongside because the SDK derives it from
+            // Exception rather than ApiException, so an HTTP 409 would otherwise skip
+            // this rollback entirely.
             WalleeHelper::log(
                 'confirmTransaction: confirm() failed for transaction ' . $transactionId
-                . ' (HTTP ' . $e->getCode() . '): ' . $e->getMessage()
+                . ' (' . get_class($e) . ' ' . $e->getCode() . '): ' . $e->getMessage()
                 . '. Rolling back order ' . ($orderId ?? 'n/a') . '.'
             );
             if ($createOrderAfterPayment === 1 && !empty($orderId)) {

--- a/frontend/Handler.php
+++ b/frontend/Handler.php
@@ -12,6 +12,7 @@ use Plugin\jtl_wallee\Services\WalleeTransactionService;
 use Plugin\jtl_wallee\WalleeHelper;
 use Wallee\Sdk\ApiClient;
 use Wallee\Sdk\ApiException;
+use Wallee\Sdk\VersioningException;
 use Wallee\Sdk\Model\TransactionState;
 
 final class Handler
@@ -276,13 +277,13 @@ final class Handler
 
         try {
             $this->confirmTransaction($spaceId, $createdTransactionId);
-        } catch (ApiException $e) {
+        } catch (ApiException | VersioningException $e) {
             // The service already cancelled the JTL order it had just created.
             // Redirect to the standard fail page so the user sees a sensible
             // error instead of an unhandled exception.
             WalleeHelper::log(
-                'getRedirectUrlAfterCreatedTransaction: confirm failed (HTTP '
-                . $e->getCode() . '): ' . $e->getMessage()
+                'getRedirectUrlAfterCreatedTransaction: confirm failed ('
+                . get_class($e) . ' ' . $e->getCode() . '): ' . $e->getMessage()
             );
             return Shop::getURL() . '/' . WalleeHelper::PLUGIN_CUSTOM_PAGES['fail-page'][$_SESSION['cISOSprache']];
         }


### PR DESCRIPTION
`updateTransaction()` reads the transaction, takes its version and sends the update with no handling for a version conflict. It is wired to five cart hooks and the Smarty output filter (`Bootstrap.php:154`, `frontend/Handler.php:119` and `:151`), so a cart AJAX call and a page render can update the same transaction concurrently, and the second one loses.

The SDK turns the resulting HTTP 409 into a `VersioningException` in `ApiClient::callApi()`, whose message is exactly the one appearing in the shop core error log: `A versioning/locking problem occurred during the API call to /transaction/update.`

This re-reads the version and retries a bounded number of times, giving up with the original exception once the attempts are exhausted or the transaction can no longer be read.

I left the existing `MAX_RETRIES` and `PAUSE_DURATION` constants untouched even though they are currently unused: twelve attempts with a five second pause exceeds a typical `max_execution_time` and would block the customer for a full minute on a hook that runs during checkout. A version conflict is resolved by a fresh read, so a short pause and a small attempt count are enough. Glad to switch to the existing constants if they were intended for this.

Symptom reported in #10.

Verified with `php -l` on PHP 8.3.
