### PR TITLE
Release the Wawi sync flag for every successful payment

### DIFF
--- a/Migrations/Migration20260815143000.php
+++ b/Migrations/Migration20260815143000.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Plugin\jtl_wallee\Migrations;
+
+use JTL\Plugin\Migration;
+use JTL\Update\IMigration;
+
+class Migration20260815143000 extends Migration implements IMigration
+{
+    protected $description = 'Add wawi sync release marker to the wallee_transactions table';
+
+    /**
+     * @inheritdoc
+     */
+    public function up()
+    {
+        $this->execute("ALTER TABLE `wallee_transactions`
+            ADD COLUMN `wawi_sync_released` tinyint(1) NOT NULL DEFAULT '0'
+            AFTER `cancellation_email_sent`;");
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function down()
+    {
+        $this->execute("ALTER TABLE `wallee_transactions` DROP COLUMN `wawi_sync_released`;");
+    }
+}

--- a/Services/WalleeTransactionService.php
+++ b/Services/WalleeTransactionService.php
@@ -1041,6 +1041,56 @@ class WalleeTransactionService
     }
 
     /**
+     * Hands an order over to Wawi, at most once per order.
+     *
+     * cAbgeholt cannot tell "the plugin parked this order while it was still unpaid" apart
+     * from "Wawi has already collected it", so releasing it unconditionally would put a
+     * collected order back into the export queue on every repeated webhook delivery. The
+     * marker column records that the release already happened.
+     *
+     * @param int $orderId
+     * @return bool True when this call performed the release.
+     */
+    public function releaseOrderToWawiOnce(int $orderId): bool
+    {
+        if ($orderId <= 0) {
+            return false;
+        }
+
+        if (!WalleeHelper::checkDBColumnExists('wallee_transactions', 'wawi_sync_released')) {
+            // Migration has not run yet. Keep the previous behaviour rather than never
+            // releasing the order at all.
+            $this->updateWawiSyncFlag($orderId, self::LET_SYNC_TO_WAWI);
+            return true;
+        }
+
+        $db = Shop::Container()->getDB();
+        $affected = (int)$db->queryPrepared(
+            "UPDATE wallee_transactions
+                SET wawi_sync_released = 1, updated_at = NOW()
+            WHERE order_id = :orderId
+                AND wawi_sync_released = 0",
+            ['orderId' => (string)$orderId],
+            ReturnType::AFFECTED_ROWS
+        );
+
+        if ($affected < 1) {
+            $row = $db->select('wallee_transactions', 'order_id', (string)$orderId);
+            if ($row !== null) {
+                WalleeHelper::log("releaseOrderToWawiOnce: Order $orderId was already released to Wawi.");
+                return false;
+            }
+
+            // No local record to mark, which is not a reason to withhold the order.
+            WalleeHelper::log("releaseOrderToWawiOnce: No local record for order $orderId, releasing anyway.");
+        }
+
+        $this->updateWawiSyncFlag($orderId, self::LET_SYNC_TO_WAWI);
+
+        return true;
+    }
+
+    /**
      * @param int $orderId
      * @param $flag
      * @return void

--- a/Services/WalleeTransactionService.php
+++ b/Services/WalleeTransactionService.php
@@ -890,11 +890,17 @@ class WalleeTransactionService
     }
 
     /**
-     * @param string $orderReference
+     * @param string|null $orderReference
      * @return void
      */
-    public function handleNextOrderReferenceNumber(string $orderReference): void
+    public function handleNextOrderReferenceNumber(?string $orderReference): void
     {
+        // Orders created by the shop before payment draw their number from the native
+        // JTL counter, so no reference reaches the metadata and there is nothing to advance.
+        if ($orderReference === null || $orderReference === '') {
+            return;
+        }
+
         if ($this->isPreventFromDuplicatedOrders() === false) {
             // Updates order number for next order. Increase by 1 if is needed
             WalleeHelper::createOrderNo(true, $orderReference);

--- a/Services/WalleeTransactionService.php
+++ b/Services/WalleeTransactionService.php
@@ -1058,9 +1058,16 @@ class WalleeTransactionService
         }
 
         if (!WalleeHelper::checkDBColumnExists('wallee_transactions', 'wawi_sync_released')) {
-            // Migration has not run yet. Keep the previous behaviour rather than never
-            // releasing the order at all.
+            // Migration has not run yet, which happens when the files are updated without
+            // the plugin version being raised. Releasing the order is still better than
+            // withholding it, but without the marker every repeated delivery releases it
+            // again, so say so rather than let it look intentional.
+            WalleeHelper::log(
+                'releaseOrderToWawiOnce: column wawi_sync_released is missing, releasing order '
+                . $orderId . ' without the repeat guard. Run the plugin migrations.'
+            );
             $this->updateWawiSyncFlag($orderId, self::LET_SYNC_TO_WAWI);
+
             return true;
         }
 

--- a/Webhooks/Strategies/WalleeNameOrderUpdateTransactionInvoiceStrategy.php
+++ b/Webhooks/Strategies/WalleeNameOrderUpdateTransactionInvoiceStrategy.php
@@ -71,7 +71,7 @@ class WalleeNameOrderUpdateTransactionInvoiceStrategy implements WalleeOrderUpda
 
                 $order = new Bestellung($orderId);
                 $this->transactionService->addIncomingPayment((string)$transactionId, $order, $transaction);
-                $this->transactionService->handleNextOrderReferenceNumber($transaction->getMetaData()['order_no']);
+                $this->transactionService->handleNextOrderReferenceNumber($transaction->getMetaData()['order_no'] ?? null);
                 print 'Order ' . $orderId . ' status was updated to paid. Triggered by Transaction Invoice webhook.';
                 break;
         }

--- a/Webhooks/Strategies/WalleeNameOrderUpdateTransactionInvoiceStrategy.php
+++ b/Webhooks/Strategies/WalleeNameOrderUpdateTransactionInvoiceStrategy.php
@@ -71,6 +71,7 @@ class WalleeNameOrderUpdateTransactionInvoiceStrategy implements WalleeOrderUpda
 
                 $order = new Bestellung($orderId);
                 $this->transactionService->addIncomingPayment((string)$transactionId, $order, $transaction);
+                $this->transactionService->updateWawiSyncFlag($orderId, $this->transactionService::LET_SYNC_TO_WAWI);
                 $this->transactionService->handleNextOrderReferenceNumber($transaction->getMetaData()['order_no'] ?? null);
                 print 'Order ' . $orderId . ' status was updated to paid. Triggered by Transaction Invoice webhook.';
                 break;

--- a/Webhooks/Strategies/WalleeNameOrderUpdateTransactionInvoiceStrategy.php
+++ b/Webhooks/Strategies/WalleeNameOrderUpdateTransactionInvoiceStrategy.php
@@ -65,13 +65,19 @@ class WalleeNameOrderUpdateTransactionInvoiceStrategy implements WalleeOrderUpda
 
             //case TransactionInvoiceState::NOT_APPLICABLE:
             case TransactionInvoiceState::PAID:
+                // Read before anything below moves the order to BEZAHLT, so that an order
+                // cancelled by an earlier webhook is still recognisable as cancelled.
+                $statusBeforePayment = (int)(new Bestellung($orderId))->cStatus;
+
                 if (!$this->orderService->updateOrderStatus($orderId, \BESTELLUNG_STATUS_OFFEN, \BESTELLUNG_STATUS_BEZAHLT)) {
                     $this->orderService->updateOrderStatus($orderId, \BESTELLUNG_STATUS_IN_BEARBEITUNG, \BESTELLUNG_STATUS_BEZAHLT);
                 }
 
                 $order = new Bestellung($orderId);
                 $this->transactionService->addIncomingPayment((string)$transactionId, $order, $transaction);
-                $this->transactionService->updateWawiSyncFlag($orderId, $this->transactionService::LET_SYNC_TO_WAWI);
+                if ($statusBeforePayment !== \BESTELLUNG_STATUS_STORNO) {
+                    $this->transactionService->releaseOrderToWawiOnce($orderId);
+                }
                 $this->transactionService->handleNextOrderReferenceNumber($transaction->getMetaData()['order_no'] ?? null);
                 print 'Order ' . $orderId . ' status was updated to paid. Triggered by Transaction Invoice webhook.';
                 break;

--- a/Webhooks/Strategies/WalleeNameOrderUpdateTransactionStrategy.php
+++ b/Webhooks/Strategies/WalleeNameOrderUpdateTransactionStrategy.php
@@ -66,17 +66,17 @@ class WalleeNameOrderUpdateTransactionStrategy implements WalleeOrderUpdateStrat
                 if ($order && (int )$order->cStatus !== \BESTELLUNG_STATUS_BEZAHLT) {
                     $orderData = $order->fuelleBestellung();
                     $this->transactionService->addIncomingPayment((string)$transactionId, $orderData, $transaction);
-                    $this->transactionService->updateWawiSyncFlag($orderId, $this->transactionService::LET_SYNC_TO_WAWI);
                     $this->transactionService->handleNextOrderReferenceNumber($transaction->getMetaData()['order_no'] ?? null);
                 }
+                $this->releaseOrderToWawi($orderId);
                 break;
 
             case TransactionState::AUTHORIZED:
                 $order = new Bestellung($orderId);
                 if ($order && (int )$order->cStatus === \BESTELLUNG_STATUS_OFFEN) {
-                    $this->transactionService->updateWawiSyncFlag($orderId, $this->transactionService::LET_SYNC_TO_WAWI);
                     $this->transactionService->handleNextOrderReferenceNumber($transaction->getMetaData()['order_no'] ?? null);
                 }
+                $this->releaseOrderToWawi($orderId);
                 break;
 
             case TransactionState::FAILED:
@@ -88,5 +88,25 @@ class WalleeNameOrderUpdateTransactionStrategy implements WalleeOrderUpdateStrat
                 break;
         }
         $this->transactionService->updateTransactionStatus($transactionId, $transactionState);
+    }
+
+    /**
+     * Hands a successfully paid order over to Wawi.
+     *
+     * Kept outside the order status checks above: a transaction invoice webhook can mark the
+     * order paid before this one arrives, and an order that is no longer OFFEN or is already
+     * BEZAHLT would then never have its sync flag released, leaving it invisible to Wawi.
+     *
+     * @param int $orderId
+     * @return void
+     */
+    private function releaseOrderToWawi(int $orderId): void
+    {
+        $order = new Bestellung($orderId);
+        if ((int)$order->cStatus === \BESTELLUNG_STATUS_STORNO) {
+            return;
+        }
+
+        $this->transactionService->updateWawiSyncFlag($orderId, $this->transactionService::LET_SYNC_TO_WAWI);
     }
 }

--- a/Webhooks/Strategies/WalleeNameOrderUpdateTransactionStrategy.php
+++ b/Webhooks/Strategies/WalleeNameOrderUpdateTransactionStrategy.php
@@ -67,7 +67,7 @@ class WalleeNameOrderUpdateTransactionStrategy implements WalleeOrderUpdateStrat
                     $orderData = $order->fuelleBestellung();
                     $this->transactionService->addIncomingPayment((string)$transactionId, $orderData, $transaction);
                     $this->transactionService->updateWawiSyncFlag($orderId, $this->transactionService::LET_SYNC_TO_WAWI);
-                    $this->transactionService->handleNextOrderReferenceNumber($transaction->getMetaData()['order_no']);
+                    $this->transactionService->handleNextOrderReferenceNumber($transaction->getMetaData()['order_no'] ?? null);
                 }
                 break;
 
@@ -75,7 +75,7 @@ class WalleeNameOrderUpdateTransactionStrategy implements WalleeOrderUpdateStrat
                 $order = new Bestellung($orderId);
                 if ($order && (int )$order->cStatus === \BESTELLUNG_STATUS_OFFEN) {
                     $this->transactionService->updateWawiSyncFlag($orderId, $this->transactionService::LET_SYNC_TO_WAWI);
-                    $this->transactionService->handleNextOrderReferenceNumber($transaction->getMetaData()['order_no']);
+                    $this->transactionService->handleNextOrderReferenceNumber($transaction->getMetaData()['order_no'] ?? null);
                 }
                 break;
 

--- a/Webhooks/Strategies/WalleeNameOrderUpdateTransactionStrategy.php
+++ b/Webhooks/Strategies/WalleeNameOrderUpdateTransactionStrategy.php
@@ -63,20 +63,24 @@ class WalleeNameOrderUpdateTransactionStrategy implements WalleeOrderUpdateStrat
         switch ($transactionState) {
             case TransactionState::FULFILL:
                 $order = new Bestellung($orderId);
-                if ($order && (int )$order->cStatus !== \BESTELLUNG_STATUS_BEZAHLT) {
+                // addIncomingPayment below sets the order to BEZAHLT unconditionally, so the
+                // status has to be read before it runs to still see a cancelled order.
+                $statusBeforePayment = (int)$order->cStatus;
+                if ($order && $statusBeforePayment !== \BESTELLUNG_STATUS_BEZAHLT) {
                     $orderData = $order->fuelleBestellung();
                     $this->transactionService->addIncomingPayment((string)$transactionId, $orderData, $transaction);
                     $this->transactionService->handleNextOrderReferenceNumber($transaction->getMetaData()['order_no'] ?? null);
                 }
-                $this->releaseOrderToWawi($orderId);
+                $this->releaseOrderToWawi($orderId, $statusBeforePayment);
                 break;
 
             case TransactionState::AUTHORIZED:
                 $order = new Bestellung($orderId);
-                if ($order && (int )$order->cStatus === \BESTELLUNG_STATUS_OFFEN) {
+                $statusBeforePayment = (int)$order->cStatus;
+                if ($order && $statusBeforePayment === \BESTELLUNG_STATUS_OFFEN) {
                     $this->transactionService->handleNextOrderReferenceNumber($transaction->getMetaData()['order_no'] ?? null);
                 }
-                $this->releaseOrderToWawi($orderId);
+                $this->releaseOrderToWawi($orderId, $statusBeforePayment);
                 break;
 
             case TransactionState::FAILED:
@@ -98,15 +102,15 @@ class WalleeNameOrderUpdateTransactionStrategy implements WalleeOrderUpdateStrat
      * BEZAHLT would then never have its sync flag released, leaving it invisible to Wawi.
      *
      * @param int $orderId
+     * @param int $statusBeforePayment order status as it was before this webhook touched it
      * @return void
      */
-    private function releaseOrderToWawi(int $orderId): void
+    private function releaseOrderToWawi(int $orderId, int $statusBeforePayment): void
     {
-        $order = new Bestellung($orderId);
-        if ((int)$order->cStatus === \BESTELLUNG_STATUS_STORNO) {
+        if ($statusBeforePayment === \BESTELLUNG_STATUS_STORNO) {
             return;
         }
 
-        $this->transactionService->updateWawiSyncFlag($orderId, $this->transactionService::LET_SYNC_TO_WAWI);
+        $this->transactionService->releaseOrderToWawiOnce($orderId);
     }
 }

--- a/Webhooks/WalleeWebhookManager.php
+++ b/Webhooks/WalleeWebhookManager.php
@@ -96,7 +96,8 @@ class WalleeWebhookManager
                 $transactionStateFromWebhook = $this?->data['state'] ?? null;
 
                 $transaction = $this->transactionService->getTransactionFromPortal($entityId);
-                $orderId = (int)$transaction->getMetaData()['orderId'] ?? null;
+                $metaData = $transaction->getMetaData() ?? [];
+                $orderId = isset($metaData['orderId']) ? (int)$metaData['orderId'] : null;
 
                 if ($this->shouldSendAuthorizationEmail($transactionStateFromWebhook, $transaction, $orderId)) {
                     $this->transactionService->sendEmail($orderId, 'authorization');

--- a/frontend/wallee_thank_you_page.php
+++ b/frontend/wallee_thank_you_page.php
@@ -41,7 +41,10 @@ if ($transactionId) {
         // Wawi if the asynchronous webhook is delayed or fails.
         if ($state === TransactionState::FULFILL || $state === TransactionState::AUTHORIZED) {
             WalleeHelper::log("thank_you_page: Transaction $transactionId is successful ($state). Resetting cAbgeholt to LET_SYNC_TO_WAWI ('N').");
-            $transactionService->updateWawiSyncFlag($orderId, $transactionService::LET_SYNC_TO_WAWI);
+            // Goes through the same one time release as the webhook. Releasing here directly
+            // would leave the marker unset, and the webhook arriving afterwards would hand
+            // the order to Wawi a second time.
+            $transactionService->releaseOrderToWawiOnce($orderId);
         }
     }
 } else {


### PR DESCRIPTION
An order created before payment is stamped `cAbgeholt = NOT_SYNC_TO_WAWI` so that Wawi ignores it while it is still unpaid (`Services/WalleeTransactionService.php:184`). Only the transaction webhook and the thank-you page put the flag back, and both paths have gaps that leave a paid order permanently invisible to Wawi.

`WalleeNameOrderUpdateTransactionInvoiceStrategy` never touched the flag at all, so orders settled through a transaction invoice webhook were never handed over.

In `WalleeNameOrderUpdateTransactionStrategy` the flag sat inside the order status checks. Webhook delivery order is not guaranteed: a transaction invoice webhook can set the order to `BESTELLUNG_STATUS_BEZAHLT` before the `FULFILL` webhook arrives, at which point the `FULFILL` branch skips its entire body, flag included. The `AUTHORIZED` branch has the same problem for any order that is no longer `BESTELLUNG_STATUS_OFFEN`.

This moves the flag out of those checks into a helper that runs for both states and skips only cancelled orders, and adds the missing call to the invoice strategy.

The thank-you page fallback (`frontend/wallee_thank_you_page.php:42`) covers this only when the customer returns to the shop, which is frequently not the case for asynchronous redirect methods. That is consistent with the reports being specific to TWINT.

Symptoms reported in #12, #11 and #7.

Based on #13, since both branches touch the same lines in the strategies. Merging that one first avoids a conflict here; happy to rebase if you prefer a different order.

Verified with `php -l` on PHP 8.3.


---

Updated after a closer look at two problems with the first version of this branch.

The guard that was meant to leave cancelled orders alone never saw one. In the `FULFILL` branch `addIncomingPayment()` reaches the native `setOrderStatusToPaid()`, which writes `BESTELLUNG_STATUS_BEZAHLT` without consulting the current status, so by the time the guard re-read the order it saw a paid order instead of a cancelled one. An order cancelled on the fail page and then paid on a payment page that was still open would have been handed to Wawi as a live order. Both branches now capture the status before anything touches it, and the invoice strategy does the same, which it had no guard for at all.

Releasing the order was also unconditional, and `cAbgeholt` cannot carry that on its own: the same `'Y'` means both "the plugin parked this order while it was unpaid" and "Wawi has already collected it". Repeated deliveries are ordinary here, because the strategy reads the current portal state rather than the payload, so a late `AUTHORIZED` delivery runs the `FULFILL` branch as well. Each repeat would have cleared the collected marker and queued the order for export again.

The release is therefore recorded in a new `wawi_sync_released` column, in the same shape as the existing per transaction email markers, and performed through a single conditional update. If the migration has not run yet the previous behaviour is kept, so an order is never withheld because of it, and an order with no local record is still released since there is nothing to mark and withholding it would be worse.


One more thing that only became visible once all the branches were looked at together: the thank you page released the order to Wawi itself, calling `updateWawiSyncFlag()` directly as a fallback for a delayed webhook. That left the marker unset, so a webhook arriving afterwards found the release still outstanding and handed the order over a second time, defeating the marker in the most common path of all. It now goes through the same one time release.

The fallback for a missing marker column also records itself in the log. It is reached when the files are updated without the plugin version being raised, so the migration has not run yet. Releasing the order is still the better of the two failure modes, but without the marker every repeated delivery releases it again, and that should not look intentional to whoever reads the log later.
