### PR TITLE
Log local transaction states that were not stored

### DIFF
--- a/Services/WalleeTransactionService.php
+++ b/Services/WalleeTransactionService.php
@@ -421,15 +421,35 @@ class WalleeTransactionService
             ->fetchPaymentMethods($this->spaceId, $transactionId, 'iframe');
     }
 
-    public function updateTransactionStatus($transactionId, $newStatus)
+    /**
+     * @param $transactionId
+     * @param $newStatus
+     * @return bool True when the local record carries the new state afterwards.
+     */
+    public function updateTransactionStatus($transactionId, $newStatus): bool
     {
-        Shop::Container()
-            ->getDB()->update(
-                'wallee_transactions',
-                ['transaction_id'],
-                [$transactionId],
-                (object)['state' => $newStatus]
+        $db = Shop::Container()->getDB();
+        $db->update(
+            'wallee_transactions',
+            ['transaction_id'],
+            [(string)$transactionId],
+            (object)['state' => $newStatus]
+        );
+
+        // The affected row count cannot answer this: MySQL reports zero rows both when the
+        // row already holds the new state and when there is no row at all. Reading the record
+        // back also covers an update that was rejected rather than skipped.
+        $row = $db->select('wallee_transactions', 'transaction_id', (string)$transactionId);
+        $stored = $row !== null && (string)($row->state ?? '') === (string)$newStatus;
+
+        if (!$stored) {
+            WalleeHelper::log(
+                'updateTransactionStatus: state ' . $newStatus . ' was not stored for transaction ' . $transactionId
+                . ($row === null ? ' (no local record)' : ' (record holds ' . ($row->state ?? 'null') . ')')
             );
+        }
+
+        return $stored;
     }
 
     /**


### PR DESCRIPTION
`updateTransactionStatus()` issued an UPDATE and returned nothing, so a state that never reached the local record went unnoticed. This is how `wallee_transactions.state` ends up behind the portal with nothing in any log pointing at it, which is the complaint in #2.

The affected row count cannot carry the signal, because MySQL reports zero rows both when the row already holds the new state and when there is no row at all. The record is read back and compared instead, which also catches an update that was rejected rather than skipped, for instance under a lock wait timeout when several deliveries for one transaction arrive together. The method now reports whether the state is actually stored, and logs the mismatch either way.

Callers are deliberately left alone. Turning this into a non success response so the portal retries is the obvious next step and it is what the report asks for, but it is not safe to bolt on from the outside:

- the refund strategy writes a refund record and restores stock before the state is touched, so a retried delivery would repeat both, and the stock would climb with every retry
- a transaction whose local record is missing for good would be retried until the portal gives up, since nothing in the webhook path creates that record
- the transaction strategy prints its result before this point, so on a shop without output buffering the status code can no longer be set at all

All three need a decision about idempotency and retry policy that belongs with you rather than with a drive by patch. Happy to follow up with the response side if you tell me which shape you want.

One thing found while in here, unrelated to this change: `transaction_id` is declared `varchar(16)` while portal transaction identifiers are 64 bit, so a sufficiently large identifier cannot round trip through this table.

Verified with `php -l` on PHP 8.3. I have no JTL Shop instance to exercise the webhook path end to end.
