### PR TITLE
Stop the Wawi sync hook from overwriting a shipped order status

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -199,11 +199,19 @@ class Bootstrap extends Bootstrapper
                 }
                 $paymentMethodEntity = new Zahlungsart($order->kZahlungsart);
 
-                if ($order->cStatus != \BESTELLUNG_STATUS_VERSANDT && $paymentMethodEntity->cAnbieter === 'Wallee') {
+                // The shop writes the new status before this hook runs, so the order read above
+                // already carries it. Only restore 'Bezahlt' when the sync dropped the order
+                // below it, leaving a shipped or partially shipped order as it is. The status
+                // codes are not monotonic, so cancelled has to be excluded by name.
+                $currentStatus = (int)$order->cStatus;
+                $needsPaidStatus = $currentStatus !== \BESTELLUNG_STATUS_STORNO
+                    && $currentStatus < \BESTELLUNG_STATUS_BEZAHLT;
+
+                if ($needsPaidStatus && $paymentMethodEntity->cAnbieter === 'Wallee') {
                     WalleeHelper::log("HOOK_BESTELLUNGEN_XML_BEARBEITESET: Triggered for Order $orderId. Setting status to Paid.");
                     $moduleId = $paymentMethodEntity->cModulId ?? '';
                     $paymentMethod = new Method($moduleId);
-                    // We keep setOrderStatusToPaid to ensure the order transitions to 'Bezahlt' (status 3) 
+                    // We keep setOrderStatusToPaid to ensure the order transitions to 'Bezahlt' (status 3)
                     // after Wawi sync, instead of staying at 'In Bearbeitung' (status 2).
                     $paymentMethod->setOrderStatusToPaid($order);
                     // We intentionally do NOT call updateWawiSyncFlag here anymore. 


### PR DESCRIPTION
Merchants report in #5 and #8 that the status of a shipped order falls back to paid. This is the part of it that lives in the plugin.

In `includes/src/dbeS/Sync/Orders.php` the shop computes the new order state, writes it to the database, and only then fires `HOOK_BESTELLUNGEN_XML_BEARBEITESET`, passing the pre sync snapshot as `oBestellung`. I checked this against both 5.3.2, the version in the reports, and 5.5.3; the sequence is identical. So the order this hook re-reads already carries the status Wawi just assigned, and the guard against `BESTELLUNG_STATUS_VERSANDT` was checking the wrong thing.

Two cases went wrong:

- a partially shipped order, which `getOrderState()` sets to `BESTELLUNG_STATUS_TEILVERSANDT` when Wawi reports `nKomplettAusgeliefert` as 0 alongside a delivery note, passed the guard and was pushed back to `BESTELLUNG_STATUS_BEZAHLT`. This was self sustaining: the pre sync status was paid again on the next sync, so the entry condition kept matching and such an order could never settle on partially shipped
- an already paid order passed the guard too on every plain data set, where `setOrderStatusToPaid()` does nothing except rewrite `dBezahltDatum` to the current time, so the payment date drifted forward with each sync

Fully shipped orders were already unaffected, since the re-read status matched the guard exactly. Restoring the paid status is still worth doing, so it is narrowed rather than removed: `getOrderState()` only reports paid when Wawi itself flags the order as paid, so an order Wallee has settled but Wawi has not can legitimately drop back to `BESTELLUNG_STATUS_IN_BEARBEITUNG`.

Cancelled is excluded by name rather than by the comparison, because it sorts below every other code and a bare less than test would sweep it in. On a stock shop that state is not reachable here, since the entry condition requires a pre sync status of paid, but the hook that computes the state passes it by reference, so another plugin can write anything into it.

One consequence worth naming: where the order stays at or above paid, `dBezahltDatum` is no longer rewritten, so a data set carrying no payment date from Wawi now leaves the column as the shop set it, which may be null.

Two related defects I did not touch here, since they sit in the webhook path rather than the sync path, but they produce the same symptom: `addIncomingPayment()` reaches `setOrderStatusToPaid()` unconditionally, and both the `FULFILL` branch of the transaction strategy and the `PAID` branch of the invoice strategy can reach it for an order that is already shipped. Deferred payment methods make that ordering routine. Glad to send a follow up if it is useful.

Verified with `php -l` on PHP 8.3. No JTL Wawi instance here, so the sequence above is read from the core sources rather than observed.
