### PR TITLE
Fix the iframe auto submit for payment methods without an input form

### DIFF
--- a/frontend/js/wallee-app.js
+++ b/frontend/js/wallee-app.js
@@ -35,6 +35,9 @@
         cart_recreate_url: null,
         cart_recreate_url_id: 'cartRecreateUrl',
         handler: null,
+        collapsed_iframe_height: 30,
+        auto_submit_timer: null,
+        submitted: false,
 
         /**
          * Initialize plugin
@@ -106,20 +109,18 @@
                 });
                 WalleeCheckout.handler.setInitializeCallback(() => {
                     let loader = document.getElementById(WalleeCheckout.loader_id);
-                    loader.parentNode.removeChild(loader);
+                    if (loader && loader.parentNode) {
+                        loader.parentNode.removeChild(loader);
+                    }
                     WalleeCheckout.activateLoader(false);
-                    setTimeout(function () {
-                        if (this.measureIframe(iframeContainer) < 30) {
-                            WalleeCheckout.handler.submit();
-                        }
-                    }, 1000);
+                    WalleeCheckout.scheduleAutoSubmit(function () {
+                        return WalleeCheckout.measureIframe(iframeContainer);
+                    });
                 });
-                WalleeCheckout.handler.setHeightChangeCallback((height)=>{
-                    setTimeout(function () {
-                        if(height < 30) {
-                            WalleeCheckout.handler.submit();
-                        }
-                    }, 1000);
+                WalleeCheckout.handler.setHeightChangeCallback((height) => {
+                    WalleeCheckout.scheduleAutoSubmit(function () {
+                        return height;
+                    });
                 });
                 WalleeCheckout.handler.create(iframeContainer);
             }
@@ -131,17 +132,66 @@
          * @return {int}
          */
         measureIframe: function (iframeContainer) {
+            if (!iframeContainer) {
+                return 0;
+            }
+
             if (iframeContainer.tagName.toLowerCase() === 'iframe') {
                 return iframeContainer.offsetHeight;
             }
 
-            iframeContainer.childNodes.forEach( child => {
-                if (child.tagName.toLowerCase() === 'iframe') {
-                    return child.offsetHeight;
-                }
-            })
+            const iframe = iframeContainer.querySelector('iframe');
 
-            return 0;
+            return iframe ? iframe.offsetHeight : 0;
+        },
+
+        /**
+         * Queues the height driven auto submit.
+         *
+         * The height change callback fires on every change, so each call replaces the
+         * pending one instead of stacking a timer per event.
+         *
+         * @param resolveHeight function returning the height to judge once the delay is over
+         */
+        scheduleAutoSubmit: function (resolveHeight) {
+            window.clearTimeout(WalleeCheckout.auto_submit_timer);
+            WalleeCheckout.auto_submit_timer = window.setTimeout(function () {
+                WalleeCheckout.autoSubmitIfCollapsed(resolveHeight());
+            }, 1000);
+        },
+
+        /**
+         * Submits a payment method that renders no input of its own, which the iframe
+         * signals by staying below the collapsed height.
+         *
+         * @param height
+         */
+        autoSubmitIfCollapsed: function (height) {
+            // Negated on purpose rather than written as a >= test: a height that is not a
+            // number must not start a payment, and NaN compares false against every bound.
+            if (!(Number(height) < WalleeCheckout.collapsed_iframe_height)) {
+                return;
+            }
+
+            WalleeCheckout.submitOnce();
+        },
+
+        /**
+         * Hands the payment to the iframe handler, at most once per attempt.
+         *
+         * A second submit lands on top of a payment that is already in flight, which closes
+         * the 3D Secure window and breaks the return from an external payment app. The
+         * iframe reports a collapsed height while it shows a challenge, so without this the
+         * height driven submit above fires straight into a running payment.
+         */
+        submitOnce: function () {
+            if (WalleeCheckout.submitted) {
+                return;
+            }
+
+            WalleeCheckout.submitted = true;
+            WalleeCheckout.activateLoader(true);
+            WalleeCheckout.handler.submit();
         },
 
         /**
@@ -151,7 +201,7 @@
         validationCallBack: function (validationResult) {
             if (validationResult.success) {
                 document.querySelector(this.payment_method_handler_status).value = true;
-                WalleeCheckout.handler.submit();
+                WalleeCheckout.submitOnce();
             } else {
                 document.body.scrollTop = 0;
                 document.documentElement.scrollTop = 0;
@@ -160,6 +210,10 @@
                     WalleeCheckout.showErrors(validationResult.errors);
                 }
                 document.querySelector(this.payment_method_handler_status).value = false;
+                // Nothing is in flight after a failed validation, so a later attempt has to
+                // get through. Methods whose buttons are hidden depend on this: their only
+                // way back in is the height driven submit.
+                WalleeCheckout.submitted = false;
                 WalleeCheckout.activateLoader(false);
             }
         },


### PR DESCRIPTION
Payment methods that render no fields of their own, TWINT among them, have their pay and cancel buttons hidden by `frontend/template/wallee_iframe.tpl`, so the only thing that starts the payment is the automatic submit driven by the iframe height. Both paths into it were broken, which is a plausible account of #4 and the mobile half of #8.

The initialize path called `this.measureIframe(...)` from inside a plain `setTimeout` callback. A timer callback runs with the global object as its this value, and only `WalleeCheckout` is exported to `window`, so the call threw and that branch never ran at all.

`measureIframe()` itself always answered 0 for a container that is not an iframe. The `return` sat inside a `forEach` callback, so it left the iteration rather than the function, and `childNodes` also yields the text nodes around the markup, whose missing `tagName` made the callback throw before reaching it. The iframe is now looked up directly, which also survives the vendor wrapping it in an element of its own.

That left the height change callback as the only working path, and it fires on every height change with no debounce, queueing an independent timer each time. Those are now collapsed into one.

The submit itself is guarded so only one runs at a time, and the guard covers the manual path as well, not just the automatic one. That part matters for the card case in #4: the payment is started by the button, and the iframe collapses while the 3D Secure challenge is up, so an unguarded height driven submit lands straight on top of a payment in flight. The guard is released again when validation comes back unsuccessful, since nothing is running then and a method with hidden buttons would otherwise be left on a page with no way forward.

The height test is written as a negated less than rather than a greater or equal, so a height that is not a number leaves the payment alone instead of starting it.

Reproducing this needs a checkout against a payment method that collapses its iframe, which I cannot set up, so confirmation on a sandbox space would be welcome. The broken this binding and the misplaced return are plain defects either way.

Two things found while in here and deliberately left alone, both candidates for a separate change:

- the `popstate` handler cannot tell its two history entries apart, since both are pushed with the same state object, so any history navigation after load sends the customer to cart recreation rather than only the back gesture it was written for
- the checkout URL pushed into the address bar is the hardcoded English slug `/wallee-payment-page`, although the route is localised in `WalleeHelper::PLUGIN_CUSTOM_PAGES` and the leading slash also ignores a shop installed in a subdirectory. A reload on a German, Italian or French shop lands on a URL that does not resolve, and returning from an external payment app is exactly when a mobile browser may decide to reload

Verified with `node --check`. No behavioural test, for the reason above.
