### PR TITLE
Parenthesise the null coalescing defaults so they can take effect

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -159,7 +159,7 @@ class Bootstrap extends Bootstrapper
         $dispatcher->listen('shop.hook.' . \HOOK_SMARTY_OUTPUTFILTER, [$handler, 'contentUpdate']);
         $dispatcher->listen('shop.hook.' . \HOOK_BESTELLABSCHLUSS_INC_BESTELLUNGINDB_ENDE, function ($args) use ($handler) {
             $obj = Shop::Container()->getDB()->selectSingleRow('tzahlungsart', 'kZahlungsart', (int)$_SESSION['AktiveZahlungsart']);
-            $createOrderAfterPayment = (int)$obj->nWaehrendBestellung ?? 1;
+            $createOrderAfterPayment = (int)($obj->nWaehrendBestellung ?? 1);
             if ($createOrderAfterPayment === 0) {
                 if (isset($_SESSION['Zahlungsart']->cModulId) && str_contains(\strtolower($_SESSION['Zahlungsart']->cModulId), 'wallee')) {
                     $redirectUrl = $handler->getRedirectUrlAfterCreatedTransaction($args['oBestellung']);

--- a/Services/WalleeTransactionService.php
+++ b/Services/WalleeTransactionService.php
@@ -146,7 +146,7 @@ class WalleeTransactionService
         $pendingTransaction->setShippingAddress($this->createShippingAddress());
 
         $obj = Shop::Container()->getDB()->selectSingleRow('tzahlungsart', 'kZahlungsart', (int)$_SESSION['AktiveZahlungsart']);
-        $createOrderAfterPayment = (int)$obj->nWaehrendBestellung ?? 1;
+        $createOrderAfterPayment = (int)($obj->nWaehrendBestellung ?? 1);
         $orderReferenceNumber = null;
 
         $order = new \stdClass();

--- a/Webhooks/Strategies/WalleeNameOrderUpdateRefundStrategy.php
+++ b/Webhooks/Strategies/WalleeNameOrderUpdateRefundStrategy.php
@@ -55,12 +55,12 @@ class WalleeNameOrderUpdateRefundStrategy implements WalleeOrderUpdateStrategyIn
          * @var \Wallee\Sdk\Model\Refund $refund
          */
         $refund = $this->refundService->getRefundFromPortal($entityId);
-        $orderId = (int)$refund->getTransaction()->getMetaData()['orderId'] ?? '';
+        $orderId = (int)($refund->getTransaction()->getMetaData()['orderId'] ?? 0);
 
         if (empty($orderId)) {
             $transactionId = (int)$refund->getTransaction()->getId();
             $localTransaction = $this->transactionService->getLocalWalleeTransactionById((string)$transactionId);
-            $orderId = (int)$localTransaction->order_id;
+            $orderId = (int)($localTransaction->order_id ?? 0);
         }
         $this->refundService->createRefundRecord((int)$entityId, $orderId, $refund->getAmount());
 

--- a/adminmenu/AdminTabProvider.php
+++ b/adminmenu/AdminTabProvider.php
@@ -219,7 +219,7 @@ class AdminTabProvider
                     exit;
                 }
                 
-                $amount = (float) $_REQUEST['amount'] ?? 0;
+                $amount = (float)($_REQUEST['amount'] ?? 0);
                 $this->processRefund($transactionId, $amount);
                 break;
             

--- a/frontend/Handler.php
+++ b/frontend/Handler.php
@@ -249,7 +249,7 @@ final class Handler
         $config = WalleeHelper::getConfigByID($this->plugin->getId());
         $spaceId = $config[WalleeHelper::SPACE_ID];
 
-        $createdTransactionId = (int)$_SESSION['transactionId'] ?? null;
+        $createdTransactionId = (int)($_SESSION['transactionId'] ?? 0);
 
         if (empty($createdTransactionId)) {
             $failedUrl = Shop::getURL() . '/' . WalleeHelper::PLUGIN_CUSTOM_PAGES['fail-page'][$_SESSION['cISOSprache']];

--- a/frontend/wallee_thank_you_page.php
+++ b/frontend/wallee_thank_you_page.php
@@ -10,7 +10,8 @@ use Wallee\Sdk\Model\TransactionState;
 /** @global \JTL\Smarty\JTLSmarty $smarty */
 /** @global JTL\Plugin\PluginInterface $plugin */
 
-$transactionId = (int)$_GET['tID'] ?? null;
+$orderId = 0;
+$transactionId = (int)($_GET['tID'] ?? 0);
 if ($transactionId) {
     $apiClient = new WalleeApiClient($plugin->getId());
     $transactionService = new WalleeTransactionService($apiClient->getApiClient(), $plugin);
@@ -20,9 +21,12 @@ if ($transactionId) {
 	Shop::Container()->getLogService()->notice(
 	  "Transaction found. Starting to create order."
 	);
-    $createAfterPayment = (int)$transaction->getMetaData()['orderAfterPayment'] ?? 1;
+    // Defaults to the branch that reads the local record, which carries order_id in both
+    // configurations. The metadata key is written together with orderId, so when one is
+    // missing the other is too, and the other branch would have nothing to resolve.
+    $createAfterPayment = (int)($transaction->getMetaData()['orderAfterPayment'] ?? 0);
     if ($createAfterPayment) {
-        $orderId = (int)$transaction->getMetaData()['orderId'];
+        $orderId = (int)($transaction->getMetaData()['orderId'] ?? 0);
         $order = new Bestellung($orderId);
         $orderId = (int)$order->kBestellung;
     } else {
@@ -30,7 +34,7 @@ if ($transactionId) {
 		  "Order was not created. We created it previously and returning the ID."
 		);
         $localTransaction = $transactionService->getLocalWalleeTransactionById((string)$transactionId);
-        $orderId = (int) $localTransaction->order_id;
+        $orderId = (int)($localTransaction->order_id ?? 0);
     }
 
     if ($orderId > 0) {


### PR DESCRIPTION
A type cast binds tighter than the null coalescing operator, so `(int)$value ?? $default` casts first and hands the already cast result to the operator. The cast never yields null, the right hand side is dead code and the default is unreachable. The pattern appears in seven places across the plugin.

One of them is live today: in the admin order tab the refund amount is read this way, and from `$_REQUEST` without checking that the key exists.

The defaults are chosen to preserve what each place actually did, not what it appeared to promise. That distinction matters most on the thank you page, where the written default of 1 for `orderAfterPayment` would have sent a transaction with incomplete metadata into the branch that resolves the order from that same metadata. It finds nothing there, skips the sync flag fallback and redirects with an empty order reference. The effective value has always been 0, which takes the branch reading the local record instead, and that record carries `order_id` in both configurations, so it stays 0.

Where the default does become reachable, the two reads of `nWaehrendBestellung`, both get the same value. That keeps the branch which creates the order and the branch which decides whether to roll it back from ever disagreeing.

The thank you page also initialises the order id it reads outside the branch that assigns it, which was a genuine read of an undefined variable, and three reads of values documented as nullable no longer dereference them blindly.

Deliberately left alone: two conditions of the form `$value ?? null === 1`, which parse as `$value ?? (null === 1)`. They work as truthiness checks today, and adding the obvious parentheses would break them, because the value arrives from the database as a string and would then fail a strict comparison against an integer. Fixing those means changing the comparison, not the grouping, so it does not belong in a change about precedence.

Verified with `php -l` on PHP 8.3, and by re-running the search to confirm no instance of the pattern remains.
