### PR TITLE
Keep a failed portal call from ending the Wawi sync run

### DIFF
--- a/Services/WalleeRefundService.php
+++ b/Services/WalleeRefundService.php
@@ -49,56 +49,88 @@ class WalleeRefundService
         $this->transactionService = new WalleeTransactionService($apiClient, $plugin);
     }
 
-    public function makeRefund(string $transactionId, float $amount)
+    /**
+     * @param string $transactionId
+     * @param float $amount
+     * @return array
+     * @throws \InvalidArgumentException when the amount cannot be refunded
+     * @throws \RuntimeException when the portal rejects the refund
+     */
+    public function makeRefund(string $transactionId, float $amount): array
     {
         if ($amount <= 0) {
-            print 'Amount should be greater than 0';
-            exit;
+            throw new \InvalidArgumentException('Amount should be greater than 0');
         }
 
         $transaction = $this->transactionService->getTransactionFromPortal($transactionId);
         $transactionAmount = $transaction->getAuthorizationAmount();
         if ($amount > $transactionAmount) {
-            print 'Please make sure you are trying to refund correct amount of money';
-            exit;
+            throw new \InvalidArgumentException('Please make sure you are trying to refund correct amount of money');
         }
 
-        $state = $transaction->getState();
-        if ($state === 'FULFILL') {
-            try {
-                $refundPayload = (new RefundCreate())
-                    ->setAmount(\round($amount, 2))
-                    ->setTransaction($transactionId)
-                    ->setMerchantReference((string)mb_substr($transaction->getMerchantReference(), 0, 100, 'UTF-8'))
-                    ->setExternalId(uniqid('refund_', true))
-                    ->setType(RefundType::MERCHANT_INITIATED_ONLINE);
+        if ($transaction->getState() !== TransactionState::FULFILL) {
+            // Not an error, but the caller asked for money to be returned and none was, so
+            // it cannot pass silently either: an order cancelled at this point leaves the
+            // customer charged.
+            Shop::Container()->getLogService()->notice(
+                'Wallee: no refund for transaction ' . $transactionId . ', it is in state '
+                . $transaction->getState() . ' rather than ' . TransactionState::FULFILL
+            );
 
-                if (!$refundPayload->valid()) {
-                    print 'Refund payload invalid:' . json_encode($refundPayload->listInvalidProperties());
-                    exit;
-                }
-
-                $this->apiClient->getRefundService()->refund($this->spaceId, $refundPayload);
-
-                return [];
-            } catch (\Exception $e) {
-                $detectJsonPattern = '/
-					\{              # { character
-						(?:         # non-capturing group
-							[^{}]   # anything that is not a { or }
-							|       # OR
-							(?R)    # recurses the entire pattern
-						)*          # previous group zero or more times
-					\}              # } character
-					/x';
-                preg_match_all($detectJsonPattern, $e->getMessage(), $matches);
-                $jsonErrorMessage = $matches[0][0];
-                $errorData = \json_decode($jsonErrorMessage);
-
-                print $errorData->message;
-                exit;
-            }
+            return [];
         }
+
+        $refundPayload = (new RefundCreate())
+            ->setAmount(\round($amount, 2))
+            ->setTransaction($transactionId)
+            ->setMerchantReference((string)mb_substr((string)$transaction->getMerchantReference(), 0, 100, 'UTF-8'))
+            ->setExternalId(uniqid('refund_', true))
+            ->setType(RefundType::MERCHANT_INITIATED_ONLINE);
+
+        if (!$refundPayload->valid()) {
+            throw new \RuntimeException(
+                'Refund payload invalid: ' . json_encode($refundPayload->listInvalidProperties())
+            );
+        }
+
+        try {
+            $this->apiClient->getRefundService()->refund($this->spaceId, $refundPayload);
+        } catch (\Exception $e) {
+            throw new \RuntimeException($this->describeApiFailure($e), 0, $e);
+        }
+
+        return [];
+    }
+
+    /**
+     * Digs the readable part out of an SDK exception message.
+     *
+     * The SDK folds the raw response body into the message, so the wording the API sent is
+     * only reachable by pulling the JSON object back out of it. Falls back to the message
+     * itself when there is nothing to pull.
+     *
+     * @param \Throwable $e
+     * @return string
+     */
+    private function describeApiFailure(\Throwable $e): string
+    {
+        $detectJsonPattern = '/
+				\{              # { character
+					(?:         # non-capturing group
+						[^{}]   # anything that is not a { or }
+						|       # OR
+						(?R)    # recurses the entire pattern
+					)*          # previous group zero or more times
+				\}              # } character
+				/x';
+
+        if (!preg_match_all($detectJsonPattern, $e->getMessage(), $matches) || empty($matches[0][0])) {
+            return $e->getMessage();
+        }
+
+        $errorData = \json_decode($matches[0][0]);
+
+        return $errorData->message ?? $e->getMessage();
     }
 
     /**

--- a/adminmenu/AdminTabProvider.php
+++ b/adminmenu/AdminTabProvider.php
@@ -237,7 +237,16 @@ class AdminTabProvider
      */
     private function processRefund(?string $transactionId, float $amount): void
     {
-        $this->refundService->makeRefund($transactionId, $amount);
+        try {
+            $this->refundService->makeRefund((string)$transactionId, $amount);
+        } catch (\Throwable $e) {
+            // The service used to print and exit here itself, which is why the message is
+            // echoed rather than rendered: this action answers an admin side request.
+            Shop::Container()->getLogService()->error('Wallee refund failed: ' . $e->getMessage());
+            print $e->getMessage();
+            exit;
+        }
+
         $transaction = $this->transactionService->getTransactionFromPortal($transactionId);
         $localTransaction = $this->transactionService->getLocalWalleeTransactionById((string)$transaction->getId());
         $order = new Bestellung((int) $localTransaction->order_id);

--- a/frontend/Handler.php
+++ b/frontend/Handler.php
@@ -179,8 +179,12 @@ final class Handler
         }
 
         $transaction = $this->transactionService->getLocalWalleeTransactionById((string)$transactionId);
-        if ($transaction->state === TransactionState::AUTHORIZED) {
-            $this->transactionService->completePortalTransaction($transactionId);
+        if (($transaction->state ?? null) === TransactionState::AUTHORIZED) {
+            try {
+                $this->transactionService->completePortalTransaction($transactionId);
+            } catch (\Throwable $e) {
+                $this->reportSyncFailure('completing transaction ' . $transactionId, $e);
+            }
         }
     }
 
@@ -190,7 +194,10 @@ final class Handler
      */
     public function cancelOrderAfterWawi(array $args): void
     {
-        $order = $args['oBestellung'] ?? [];
+        $order = $args['oBestellung'] ?? null;
+        if (!$order) {
+            return;
+        }
 
         $obj = Shop::Container()->getDB()->selectSingleRow('wallee_transactions', 'order_id', $order->kBestellung);
         $transactionId = $obj->transaction_id ?? '';
@@ -202,8 +209,12 @@ final class Handler
 
         switch ((int)$order->cStatus) {
             case \BESTELLUNG_STATUS_IN_BEARBEITUNG:
-                if ($transaction->state === TransactionState::AUTHORIZED) {
-                    $this->transactionService->cancelPortalTransaction($transactionId);
+                if (($transaction->state ?? null) === TransactionState::AUTHORIZED) {
+                    try {
+                        $this->transactionService->cancelPortalTransaction($transactionId);
+                    } catch (\Throwable $e) {
+                        $this->reportSyncFailure('voiding transaction ' . $transactionId, $e);
+                    }
                 }
                 break;
 
@@ -211,11 +222,30 @@ final class Handler
                 try {
                     $portalTransaction = $this->transactionService->getTransactionFromPortal($transactionId);
                     $this->refundService->makeRefund((string)$transactionId, (float)$portalTransaction->getAuthorizationAmount());
-                } catch (\Exception $e) {
-
+                } catch (\Throwable $e) {
+                    $this->reportSyncFailure('refunding transaction ' . $transactionId, $e);
                 }
                 break;
         }
+    }
+
+    /**
+     * Records a portal call that failed while the Wawi sync was running.
+     *
+     * These are swallowed so that one order cannot abort the rest of the run, but each of
+     * them leaves the shop and the portal disagreeing about money, so none may pass
+     * unrecorded. The shop log is used rather than the plugin debug file because this is
+     * the only trace an operator gets.
+     *
+     * @param string $what
+     * @param \Throwable $e
+     * @return void
+     */
+    private function reportSyncFailure(string $what, \Throwable $e): void
+    {
+        $message = 'Wallee: ' . $what . ' failed during Wawi sync: ' . $e->getMessage();
+        Shop::Container()->getLogService()->error($message);
+        WalleeHelper::log($message);
     }
 
     /**


### PR DESCRIPTION
`WalleeRefundService::makeRefund()` answered every failure with a `print` followed by `exit`. That is survivable for the admin action it was written for, but the method is also reached from `Handler::cancelOrderAfterWawi()`, which runs inside the dbeS order sync loop. One order with an unrefundable amount therefore ended the entire run, and every order queued behind it went unprocessed until the next sync.

The service now throws, and the two callers decide what that means. The admin action keeps printing and exiting, since it answers a request of its own and the surrounding handler exits anyway. The sync path swallows the failure so that one order cannot abort the run.

The other portal calls on that path get the same treatment. Fixing only the refund would have repaired one branch of a `switch` and left its neighbour able to end the run in exactly the same way: voiding a transaction when Wawi cancels an order still in processing, and completing one from the paid status hook. All three now report through a single place, and they report to the shop log rather than the plugin debug file, because a failure here means the shop and the portal disagree about money and this is the only trace an operator gets.

Two silent paths are closed as well:

- a refund request against a transaction that is not in `FULFILL` did nothing and said nothing. That covers the ordinary case of an authorised but uncompleted transaction, where cancelling the order leaves the customer charged and no one any the wiser
- the error message extraction assumed the SDK message always contains a JSON object and indexed the match array unconditionally, so a connection error produced an undefined offset instead of the message it was trying to surface. It now falls back to the exception message, which also means the admin sees something in cases where the previous code printed an empty string and the JavaScript read that as success

Two smaller things in the same call path: the payload no longer passes a possibly null merchant reference into `mb_substr`, and the local transaction state is read defensively since the method returning it is documented as nullable.

Not addressed here, because it needs a decision rather than a fix: after a successful refund the admin action calls `setOrderStatusToPaid()` unconditionally, so a full refund leaves the order marked as paid, while the refund webhook moves the same order to cancelled. The two paths disagree about the same event, and picking one is a product decision.

Verified with `php -l` on PHP 8.3. I have no JTL Shop instance to exercise a sync run, so the call path above is read from the core sources rather than observed.
